### PR TITLE
OAPS-195: Invalid formrule not allowing people to save their details

### DIFF
--- a/CRM/Oapproviderlistapp/Form/Experience.php
+++ b/CRM/Oapproviderlistapp/Form/Experience.php
@@ -26,7 +26,7 @@ class CRM_Oapproviderlistapp_Form_Experience extends CRM_Oapproviderlistapp_Form
   }
 
   public function formRule($fields, $files, $self) {
-    if (!empty($fields['_qf_Experience_submit_done'])) {
+    if (!empty($fields['_qf_Experience_submit_done']) || !empty($fields['_qf_Experience_submit'])) {
       return TRUE;
     }
     $errors = [];

--- a/CRM/Oapproviderlistapp/Form/Experience.php
+++ b/CRM/Oapproviderlistapp/Form/Experience.php
@@ -62,15 +62,15 @@ class CRM_Oapproviderlistapp_Form_Experience extends CRM_Oapproviderlistapp_Form
         }
         $error = '';
         if (empty($fields[$fieldName])) {
-          if (strstr($fieldName, 'custom_36')) {
-            $error .= E::ts('Total number of hours') . ':<br />' . E::ts('Applicants are required to have at least 3,000 hours post-certification/registration experience.');
-          }
-          if (strstr($fieldName, 'custom_37')) {
-            $error = E::ts('Approximate number of hours that involved supervisory duties') . ':<br />' . E::ts('Applicants are required to have a minimum of 1,500 post-certification hours involving supervisory duties.');
-          }
           $error .= E::ts('All fields in Employment History are required.');
           $errors['_qf_default'] = $error;
           CRM_Core_Session::setStatus("", $error, "alert");
+        }
+        elseif (strstr($fieldName, 'custom_36') && $fields[$fieldName] < 3000) {
+          $errors['_qf_default'] .= sprintf('<strong>%s</strong>: <br /> %s', E::ts('Total number of hours'), E::ts('Applicants are required to have at least 3,000 hours post-certification/registration experience.'));
+        }
+        elseif (strstr($fieldName, 'custom_37') && $fields[$fieldName] < 1500) {
+          $errors['_qf_default'] .= sprintf('<strong>%s</strong>: <br /> %s', E::ts('Approximate number of hours that involved supervisory duties'), E::ts('Applicants are required to have a minimum of 1,500 post-certification hours involving supervisory duties.'));
         }
         elseif (strstr($fieldName, 'custom_47') && !empty($fields[$fieldName])) {
           $contact = civicrm_api3('Contact', 'get', [

--- a/templates/CRM/Oapproviderlistapp/Form/Experience.tpl
+++ b/templates/CRM/Oapproviderlistapp/Form/Experience.tpl
@@ -15,6 +15,7 @@ CRM.$(function($) {
   CRM.buildCustomData('Individual', 'Provider', 1);
   $('.crm-profile legend').hide();
   $('tr.custom_48_25-row-help-pre').insertAfter($('tr.custom_48_25-row'));
+  $('#editrow-custom_12 label').append("&nbsp;<span class='crm-marker' title='This field is required.'>*</span>");
   var empFields = [
     "custom_32",
     "custom_33",


### PR DESCRIPTION
Here are the fixes made: 
1. If someone enter number of hours less then 3000 in 'Total number of hours' then it throws a validation error : ```Applicants are required to have at least 3,000 hours post-certification/registration experience.```
2. If someone enter the number of hours less then 1500 in 'Approximate number of hours that involved supervisory duties' then it throws a validation error: ```Applicants are required to have a minimum of 1,500 post-certification hours involving supervisory duties.```
3. Earlier clicking on 'Previous' button prevents the user to go to the previous page. Fixed now
4. Earlier clicking on 'Draft' button prevents the user to submit the form and send draft email. Fixed now

Here is a screencast which demonstrates all the four fixes : 
![oaps-after](https://user-images.githubusercontent.com/3735621/87405222-bfd36280-c5dc-11ea-82eb-239efb4cfa75.gif)

